### PR TITLE
Changed Libraries due to errors 

### DIFF
--- a/FisbaReadyBeam/__init__.py
+++ b/FisbaReadyBeam/__init__.py
@@ -1,7 +1,7 @@
 import serial
 import time
 import struct
-from PyCRC.CRCCCITT import CRCCCITT
+from crc import CrcCalculator, Crc16
 
 
 class FisbaReadyBeam():
@@ -148,7 +148,8 @@ class FisbaReadyBeam():
                 command += '{:08X}'.format(struct.unpack('<I', struct.pack('<f', value))[0])
             elif isinstance(value, int):
                 command += '{:08X}'.format(1)
-        checksum = CRCCCITT().calculate(input_data=command.encode())
+        crc_calculator = CrcCalculator(Crc16.CCITT)
+        checksum = crc_calculator.calculate_checksum(command.encode())
         command += '{:04X}'.format(checksum)
         command += '\r'
         return command.encode()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-PyCRC>=0.9.2
-serial>=0.0.97
+crc>=1.2.0
+pyserial>=3.5
 odak>=0.2.0


### PR DESCRIPTION
Changed crc library from 'PyCRC' to 'crc' due to error message (ModuleNotFoundError: No module named 'PyCRC'). Seems abandoned?
Changed serial library from 'serial' to 'pyserial' due to error message (AttributeError: module 'serial' has no attribute 'Serial')

@kaanaksit I could install your requirements.txt file, but the script itself threw the above mentioned errors.
I don't know if the errors are caused by me using python 3.10 on Windows, or some other factor.
I some digging I think I found active replacement modules for the CRC and the serial module. I hope they will work on your system, too.